### PR TITLE
fix(ci): push the helm chart to the kiln helm charts repo

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -141,6 +141,5 @@ jobs:
           git fetch origin
           tag="$(git describe --tags)"
 
-          sed -i -e 's/^name: carina-csi-driver/name: carina/' charts/Chart.yaml
           helm package charts --version "${tag}"
-          HELM_EXPERIMENTAL_OCI=1 helm push "carina-${tag}.tgz" "oci://ghcr.io/kilnfi"
+          HELM_EXPERIMENTAL_OCI=1 helm push "carina-csi-driver-${tag}.tgz" "oci://ghcr.io/kilnfi/helm-charts"


### PR DESCRIPTION
Make sure the helm chart is pushed to `kilnfi/helm-charts` so that it matches the rest of our infrastructure files.